### PR TITLE
Delete wlogout and mesa-demos

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -23,7 +23,6 @@ depends=(
     'grim' # screenshot tool
     'slurp' # helper for grim
     'wob' # wayland overlay bar for brightness and volume
-    'wlogout' # nice logout menu
     'noto-fonts-emoji' # emoji font
     'foot' # terminal application
     'nerd-fonts-roboto-mono' # default monospace font
@@ -31,7 +30,6 @@ depends=(
     'jq' # parsing and manipulating json
     'khal' # calendar application around caldav
     'lm_sensors' # display sensor information
-    'mesa-demos' # required for terminal.sh script
     'manjaro-sway-wallpapers' # manjaro sway themed backgrounds
     'wf-recorder' # screen recording util
     'wl-clipboard' # copy/paste utilities for wayland


### PR DESCRIPTION
We've switched to use a Sway mode for logout actions and switched to foot as a default terminal, so terminal.sh is irrelevant now. Both dependencies can be deleted safely now.